### PR TITLE
Enable virtual build for test mode

### DIFF
--- a/packages/adapter/providers/remix_provider.ts
+++ b/packages/adapter/providers/remix_provider.ts
@@ -36,7 +36,7 @@ export default class RemixProvider {
     const vite = await this.app.container.make('vite')
     const devServer = vite.getDevServer()
     const build =
-      this.app.inDev && devServer
+      (this.app.inDev || this.app.inTest) && devServer
         ? () => devServer.ssrLoadModule('virtual:remix/server-build')
         : await import(this.remixBundle)
 


### PR DESCRIPTION
This is to be able to run end-to-end browser tests against a dev server build.

Looks like adonijs framework [forces](https://github.com/jarle/remix-adonisjs/blob/5d799395482bde617bff8135a3e8a7b8a56847e9/packages/reference-app/bin/test.ts#L13) NODE_ENV to be `test` when running tests, I suppose this is important for some internal details or the framework or the test runner, so doing something like `NODE_ENV=test npm run test` or "patching" the test launch binary are not valid options.
